### PR TITLE
Fixup stat command to properly grab the epoch when validating updates

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ update_if_needed() {
   local latest_version
 
   if installed_version="$(cat "${VERSION_FILE}" 2>/dev/null)"; then
-    last_check="$(stat -f %m "${VERSION_FILE}")"
+    last_check="$(stat -c %X "${VERSION_FILE}")"
     now="$(date +%s)"
     
     if (( (now - last_check) < UPDATE_INTERVAL_SECONDS )); then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ update_if_needed() {
   local latest_version
 
   if installed_version="$(cat "${VERSION_FILE}" 2>/dev/null)"; then
-    last_check="$(stat -c %X "${VERSION_FILE}")"
+    last_check="$(stat -c %Y "${VERSION_FILE}")"
     now="$(date +%s)"
     
     if (( (now - last_check) < UPDATE_INTERVAL_SECONDS )); then


### PR DESCRIPTION
Issue: When attempting to trigger an update (e.g. update stable -> latest_experimental) the stat command fails to properly get a value for the age of the version text file.
```shell
Recreating sdtd ... done
/server ~/steamcmd
stat: cannot read file system information for '%m': No such file or directory
```
Tracing this down, it appears to be a conflict between both filesystem mount checking (`-f`) and asking for the mount point itself (`%m`) as `%m` is not a valid format sequence when using filesystem status. Asking for the mountpoint also wouldn't check for the when the file itself was last accessed.

This fix results in the below behavior on launch (with `set -x` for debugging):
```
+ VERSION_FILE=/server/version.txt
+ mkdir -p /server
+ pushd /server
+ app_id=294420
/server ~/steamcmd
+ UPDATE_INTERVAL_SECONDS=3600
+ update_if_needed
+ local installed_version
+ local latest_version
++ cat /server/version.txt
+ installed_version=9193896
++ stat -c %X /server/version.txt
+ last_check=1659377662
++ date +%s
+ now=1659377904
+ ((  (now - last_check) < UPDATE_INTERVAL_SECONDS  ))
Skipping update check, already checked within the last 3600 seconds.
+ echo 'Skipping update check, already checked within the last 3600 seconds.'
+ return
```

One other option is to use `%X` as the format, which would defer to last change status.